### PR TITLE
Fix Multiple Webpack Runtimes Conflict

### DIFF
--- a/src/config/widgetCompiler.js
+++ b/src/config/widgetCompiler.js
@@ -80,6 +80,7 @@ class WidgetsCompilerPlugin {
       output: {
         ...webpackConfig.output,
         publicPath: `${publicRuntimeConfig.PUBLIC_BASE_URL}/_next/`,
+        uniqueName: widgetName,
         filename: 'static/widgets/[name]/index.js',
       },
       plugins: modifiedPlugins,

--- a/src/config/widgetCompiler.js
+++ b/src/config/widgetCompiler.js
@@ -80,7 +80,7 @@ class WidgetsCompilerPlugin {
       output: {
         ...webpackConfig.output,
         publicPath: `${publicRuntimeConfig.PUBLIC_BASE_URL}/_next/`,
-        uniqueName: widgetName,
+        uniqueName: 'embeddable-widget',
         filename: 'static/widgets/[name]/index.js',
       },
       plugins: modifiedPlugins,


### PR DESCRIPTION
Correct conflicts with webpack runtimes (ie when including widget in a host webpack project).  [Discussed in detail here](https://github.com/webpack/webpack/issues/11277#issuecomment-992327775) and [documented by webpack here](https://webpack.js.org/configuration/output/#outputuniquename).